### PR TITLE
fix: Apple Pencil interactions

### DIFF
--- a/lib/components/accordion/standalone-accordion.tsx
+++ b/lib/components/accordion/standalone-accordion.tsx
@@ -17,7 +17,7 @@ export const StandaloneAccordion: ComponentWithAs<
   ComponentWithAs<'div', ChakraAccordionProps>,
   StandaloneAccordionProps
 > = typedMemo((props) => {
-  const onClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
+  const onPointerUp = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (e) => {
       e.preventDefault();
       props.onToggle();
@@ -27,7 +27,7 @@ export const StandaloneAccordion: ComponentWithAs<
   return (
     <Accordion index={props.isOpen ? 0 : undefined} allowToggle>
       <AccordionItem>
-        <AccordionButton badges={props.badges} onClick={onClick}>
+        <AccordionButton badges={props.badges} onPointerUp={onPointerUp}>
           {props.label}
         </AccordionButton>
         <AccordionPanel>{props.children}</AccordionPanel>

--- a/lib/components/alert-dialog/confirmation-alert-dialog.tsx
+++ b/lib/components/alert-dialog/confirmation-alert-dialog.tsx
@@ -66,10 +66,10 @@ export const ConfirmationAlertDialog = typedMemo((props: ConfirmationAlertDialog
           <AlertDialogBody>{children}</AlertDialogBody>
 
           <AlertDialogFooter>
-            <Button ref={cancelRef} onClick={handleCancel}>
+            <Button ref={cancelRef} onPointerUp={handleCancel}>
               {cancelButtonText}
             </Button>
-            <Button colorScheme="error" onClick={handleAccept} ml={3}>
+            <Button colorScheme="error" onPointerUp={handleAccept} ml={3}>
               {acceptButtonText}
             </Button>
           </AlertDialogFooter>

--- a/lib/components/expander/expander.tsx
+++ b/lib/components/expander/expander.tsx
@@ -33,7 +33,7 @@ export const Expander = typedMemo((props: ExpanderProps) => {
 
   return (
     <Flex flexDir="column" w="full">
-      <Flex as="button" flexDir="row" alignItems="center" gap={3} py={4} px={2} onClick={onToggle} sx={buttonStyles}>
+      <Flex as="button" flexDir="row" alignItems="center" gap={3} py={4} px={2} onPointerUp={onToggle} sx={buttonStyles}>
         <Divider w="unset" flexGrow={1} sx={buttonStyles} />
         <Flex flexDir="row" alignItems="center" gap={2}>
           <Icon as={isOpen ? BiCollapseVertical : BiExpandVertical} fontSize="14px" sx={buttonStyles} />

--- a/lib/components/number-input/composite-number-input.tsx
+++ b/lib/components/number-input/composite-number-input.tsx
@@ -98,7 +98,7 @@ export const CompositeNumberInput: ComponentWithAs<
       setLocalValue(String(constrainedValue));
     }, [_fineStep, _onChange, _step, defaultValue, isInteger, localValue, max, min, precision, constrainValue]);
 
-    const onClickStepper = useCallback(() => {
+    const onPointerUpStepper = useCallback(() => {
       pushLocalValue();
     }, [pushLocalValue]);
 
@@ -133,10 +133,10 @@ export const CompositeNumberInput: ComponentWithAs<
       >
         <NumberInputField onBlur={pushLocalValue} />
         <NumberInputStepper>
-          <NumberIncrementStepper onClick={onClickStepper}>
+          <NumberIncrementStepper onPointerUp={onPointerUpStepper}>
             <ChevronUpIcon />
           </NumberIncrementStepper>
-          <NumberDecrementStepper onClick={onClickStepper}>
+          <NumberDecrementStepper onPointerUp={onPointerUpStepper}>
             <ChevronDownIcon />
           </NumberDecrementStepper>
         </NumberInputStepper>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoke-ai/ui-library",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "UI Components for Invoke's applications.",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
Apple Pencil requires a double-tab on tooltip-wrapped elements. It appears the tooltip listeners conflict w/ the `onClick`. The solution is to use `onPointerUp` instead of `onClick`, as awkward as this seems.

Also bump version.