### PR TITLE
build: use sed in tag_release.sh

### DIFF
--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Parse version from package.json
-version=$(grep -oP '"version": "\K(.*?)(?=")' package.json)
+version=$(sed -n 's/.*"version": "\(.*\)".*/\1/p' package.json)
 tag="v$version"
 
 if git rev-parse "$tag" >/dev/null 2>&1; then


### PR DESCRIPTION
On macOS we have the BSD grep which differs from GNU grep. Change to sed so it works on any platform.